### PR TITLE
Add some tests

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,22 +1,23 @@
-{-# LANGUAGE BangPatterns, TypeFamilies #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Main where
 
-import Criterion.Main (bench, defaultMain, nfIO, nf)
+import           Criterion.Main                  (bench, defaultMain, nf, nfIO)
 
 import qualified Data.Vector.Hashtables.Internal as VH
-import qualified Data.Vector.Storable.Mutable as VM
-import qualified Data.Vector.Storable as V
+import qualified Data.Vector.Storable            as V
+import qualified Data.Vector.Storable.Mutable    as VM
 
-import qualified Data.Vector.Mutable as BV
+import qualified Data.Vector.Mutable             as BV
 
-import qualified Data.HashTable.IO as H
+import qualified Data.HashTable.IO               as H
 
 -- import qualified Data.HashMap.Strict as Map
 
-import Control.Monad
-import Control.Monad.Primitive
-import Data.IORef
+import           Control.Monad
+import           Control.Monad.Primitive
+import           Data.IORef
 
 n = 100000 :: Int
 
@@ -44,7 +45,7 @@ bh = do
 
 vhfind :: VH.Dictionary (PrimState IO) VM.MVector Int VM.MVector Int -> IO Int
 vhfind ht = do
-    let go !i !s | i <= n = do 
+    let go !i !s | i <= n = do
                                 x <- VH.findEntry ht i
                                 go (i + 1) (s + x)
                  | otherwise = return s
@@ -57,7 +58,7 @@ fvhfind ht = return $ go 0 0 where
 
 bhfind :: H.BasicHashTable Int Int -> IO Int
 bhfind ht = do
-    let go !i !s | i <= n = do 
+    let go !i !s | i <= n = do
                                 Just x <- H.lookup ht i
                                 go (i + 1) (s + x)
                  | otherwise = return s
@@ -163,24 +164,21 @@ mv = do
     go 0
 
 main :: IO ()
-main =  do 
+main =  do
     h <- vh
     h2 <- bh
     fh <- fvh
     defaultMain
-        [ bench "insert hashtables cuckoo (resize)" $ nfIO htcg
-        , bench "insert hashtables cuckoo" $ nfIO htc
-        , bench "insert hashtables basic"  $ nfIO htb
+        [ bench "insert hashtables basic"  $ nfIO htb
         , bench "insert hashtables basic (resize)"  $ nfIO htbg
         , bench "insert hashtables basic (delete)"  $ nfIO htbd
-        , bench "insert hashtables linear" $ nfIO htl
         , bench "insert vector-hashtables boxed" $ nfIO vhtb
         , bench "insert vector-hashtables unboxed keys" $ nfIO vhtk
         , bench "insert vector-hashtables (resize)" $ nfIO vhtg
         , bench "insert vector-hashtables (delete)" $ nfIO vhtd
-        , bench "insert vector-hashtables" $ nfIO vht 
+        , bench "insert vector-hashtables" $ nfIO vht
         , bench "insert mutable vector boxed" $ nfIO mvb
-        , bench "insert mutable vector" $ nfIO mv 
-        , bench "hashtables basic" $ nfIO (bhfind h2)
+        , bench "insert mutable vector" $ nfIO mv
+        , bench "find hashtables basic" $ nfIO (bhfind h2)
         , bench "find vector-hashtables" $ nfIO (vhfind h)
         , bench "find vector-hashtables (frozen)" $ nfIO (fvhfind fh) ]

--- a/test/Data/Vector/HashTablesSpec.hs
+++ b/test/Data/Vector/HashTablesSpec.hs
@@ -1,0 +1,271 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+module Data.Vector.HashTablesSpec where
+
+import           Control.Monad.Primitive
+import           Data.Hashable                   (Hashable (hashWithSalt))
+import qualified Data.List                       as L
+import           Data.Primitive.MutVar
+import           Data.Proxy                      (Proxy (..))
+import qualified Data.Set                        as Set
+import           Data.Vector.Generic             (Mutable, Vector)
+import qualified Data.Vector.Generic             as VI
+import           Data.Vector.Generic.Mutable     (MVector)
+import qualified Data.Vector.Mutable             as M
+import qualified Data.Vector.Storable.Mutable    as SM
+import qualified Data.Vector.Unboxed             as U
+import qualified Data.Vector.Unboxed.Mutable     as UM
+import           GHC.Generics                    (Generic)
+import           Test.Hspec.QuickCheck           (modifyMaxSuccess)
+import           Test.QuickCheck                 (Arbitrary (..), Gen,
+                                                  NonNegative (..), Property,
+                                                  elements, forAll, generate,
+                                                  property, shuffle, vector)
+
+import           Test.Hspec                      (Spec, describe, errorCall, it,
+                                                  shouldBe, shouldThrow)
+
+import qualified Data.Vector.Hashtables.Internal as VH
+
+newtype AlwaysCollide = AC Int
+    deriving newtype (Arbitrary, SM.Storable, Num, Eq, Ord, Show)
+    deriving stock Generic
+
+instance Hashable AlwaysCollide where
+    hashWithSalt _ _ = 1
+
+listN n = do
+  keys <- vector n
+  vals <- vector n
+  let keys' = Set.toList (Set.fromList keys)
+  return (zip keys' vals)
+
+shuffledListN n = do
+  testData <- listN n
+  shuffledTestData <- shuffle testData
+  return (testData, shuffledTestData)
+
+spec :: Spec
+spec = mutableSpec
+  *> storableMutableSpec
+  *> storableKeysSpec
+  *> unboxedKeysSpec
+
+class HashTableTest ks vs where
+
+  specDescription :: Proxy ks -> Proxy vs -> String
+
+  testInit :: Proxy ks -> Proxy vs -> Int -> IO (VH.Dictionary (PrimState IO) ks Int vs Int)
+
+  testInsert :: (VH.Dictionary (PrimState IO) ks Int vs Int) -> Int -> Int -> IO ()
+
+  testAt :: (VH.Dictionary (PrimState IO) ks Int vs Int) -> Int -> IO Int
+
+  testAt' :: (VH.Dictionary (PrimState IO) ks Int vs Int) -> Int -> IO (Maybe Int)
+
+  testDelete :: (VH.Dictionary (PrimState IO) ks Int vs Int) -> Int -> IO ()
+
+  testInitCollide
+    :: Proxy ks
+    -> Proxy vs
+    -> Int
+    -> IO (VH.Dictionary (PrimState IO) ks AlwaysCollide vs Int)
+
+  testInsertCollide
+    :: (VH.Dictionary (PrimState IO) ks AlwaysCollide vs Int) -> AlwaysCollide -> Int -> IO ()
+
+  testAtCollide
+    :: (VH.Dictionary (PrimState IO) ks AlwaysCollide vs Int) -> AlwaysCollide -> IO Int
+
+  testFromList
+    :: Proxy ks -> Proxy vs -> [(Int, Int)] -> IO (VH.Dictionary (PrimState IO) ks Int vs Int)
+
+  testToList :: VH.Dictionary (PrimState IO) ks Int vs Int -> IO [(Int, Int)]
+
+  testLength :: VH.Dictionary (PrimState IO) ks Int vs Int -> IO Int
+
+mkSpec
+  :: forall ks vs. (HashTableTest ks vs)
+  => Proxy ks -> Proxy vs -> Spec
+mkSpec ksp vsp = describe (specDescription ksp vsp) $
+    modifyMaxSuccess (const 1000) $ do
+      it "lookup for inserted value at specific index returns value" $
+        property prop_insertLookup'
+
+      it "lookup for inserted value at specific index returns nothing" $
+        property prop_insertLookupNothing'
+
+      it "lookup for inserted value at specific index throws error" $
+        property prop_insertLookupError'
+
+      it "lookup for updated value at specific index returns updated value" $
+        property prop_insertUpdateLookup'
+
+      it "lookup for deleted value at specific index returns nothing" $
+        property prop_insertDeleteLookupNothing'
+
+      it "lookup for deleted value at specific index throws error" $
+        property prop_insertDeleteLookupError'
+
+      it "table size increases when multiple elements added" $
+        property prop_insertMultipleElements'
+
+      it "lookup for inserted value with hash collision returns value" $
+        property prop_insertLookupHashCollisions'
+
+      it "fromList . toList === id" $ property prop_fromListToList'
+
+  where
+    prop_insertLookup'
+      :: HashTableTest ks vs => (Int, Int) -> IO ()
+    prop_insertLookup' (x, y) = do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 10
+      testInsert ht x y
+      v <- testAt ht x
+      v `shouldBe` y
+
+    prop_insertLookupNothing' :: HashTableTest ks vs => (Int, Int) -> IO ()
+    prop_insertLookupNothing' (x, y) = do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 10
+      testInsert ht (x + 1) y
+      v <- testAt' ht x
+      v `shouldBe` Nothing
+
+    prop_insertLookupError' :: HashTableTest ks vs => (Int, Int) -> IO ()
+    prop_insertLookupError' (x, y) = do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 10
+      testInsert ht (x + 1) y
+      testAt ht x `shouldThrow` errorCall "KeyNotFoundException!"
+
+    prop_insertUpdateLookup' :: HashTableTest ks vs => (Int, Int) -> IO ()
+    prop_insertUpdateLookup' (x, y) = do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 10
+      testInsert ht x y
+      testInsert ht x (y + 1)
+      v <- testAt ht x
+      v `shouldBe` (y + 1)
+
+    prop_insertDeleteLookupNothing' :: HashTableTest ks vs => (Int, Int) -> IO ()
+    prop_insertDeleteLookupNothing' (x, y) = do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 10
+      testInsert ht x y
+      testDelete ht x
+      v <- testAt' ht x
+      v `shouldBe` Nothing
+
+    prop_insertDeleteLookupError' :: HashTableTest ks vs => (Int, Int) -> IO ()
+    prop_insertDeleteLookupError' (x, y) = do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 10
+      testInsert ht 0 1
+      testDelete ht 0
+      testAt ht 0 `shouldThrow` errorCall "KeyNotFoundException!"
+
+    prop_insertMultipleElements'
+      :: HashTableTest ks vs
+      => (NonNegative Int) -> Property
+    prop_insertMultipleElements' (NonNegative n) = forAll (listN n) $ \xs -> do
+      ht <- testInit (Proxy @ks) (Proxy @vs) 2
+      mapM_ (uncurry (testInsert ht)) xs
+      htl <- testLength ht
+      htl `shouldBe` (length . Set.toList . Set.fromList) (fst <$> xs)
+
+    prop_insertLookupHashCollisions'
+      :: HashTableTest ks vs => (AlwaysCollide, Int) -> (AlwaysCollide, Int) -> IO ()
+    prop_insertLookupHashCollisions' (x1, y1) (x2, y2) = do
+      ht <- testInitCollide (Proxy @ks) (Proxy @vs) 10
+      let x2' = if x1 /= x2 then x2 else x2 + 1
+      testInsertCollide ht x1 y1
+      testInsertCollide ht x2' y2
+      v <- testAtCollide ht x1
+      v `shouldBe` y1
+
+    prop_fromListToList' (NonNegative n) = forAll (shuffledListN n) $ \(xs, ys) -> do
+      ht <- testFromList (Proxy @ks) (Proxy @vs) xs
+      xs' <- testToList ht
+      L.sort xs' `shouldBe` L.sort ys
+
+
+instance HashTableTest M.MVector M.MVector where
+  specDescription _ _ = "Data.Vector.HashTables.Mutable keys and values"
+  testInit _ _ n = VH.initialize n
+  testInitCollide _ _ n = VH.initialize n
+  testInsert = VH.insert
+  testAt = VH.at
+  testAt' = VH.at'
+  testDelete = VH.delete
+  testInsertCollide = VH.insert
+  testAtCollide = VH.at
+
+  testLength = VH.length
+  testFromList _ _ = VH.fromList
+  testToList = VH.toList
+
+mutableSpec :: Spec
+mutableSpec = mkSpec (Proxy :: Proxy M.MVector) (Proxy :: Proxy M.MVector)
+
+
+instance HashTableTest SM.MVector SM.MVector where
+  specDescription _ _ = "Data.Vector.HashTables.Storable.Mutable keys and values"
+  testInit _ _ n = VH.initialize n
+  testInitCollide _ _ n = VH.initialize n
+  testInsert = VH.insert
+  testAt = VH.at
+  testAt' = VH.at'
+  testDelete = VH.delete
+  testInsertCollide = VH.insert
+  testAtCollide = VH.at
+
+  testLength = VH.length
+  testFromList _ _ = VH.fromList
+  testToList = VH.toList
+
+storableMutableSpec :: Spec
+storableMutableSpec = mkSpec (Proxy @SM.MVector) (Proxy @SM.MVector)
+
+
+instance HashTableTest SM.MVector M.MVector where
+  specDescription _ _ = "Data.Vector.HashTables.Mutable keys and Data.Vector.HashTables.Storable.Mutable values"
+  testInit _ _ n = VH.initialize n
+  testInitCollide _ _ n = VH.initialize n
+  testInsert = VH.insert
+  testAt = VH.at
+  testAt' = VH.at'
+  testDelete = VH.delete
+  testInsertCollide = VH.insert
+  testAtCollide = VH.at
+
+  testLength = VH.length
+  testFromList _ _ = VH.fromList
+  testToList = VH.toList
+
+storableKeysSpec :: Spec
+storableKeysSpec = mkSpec (Proxy @SM.MVector) (Proxy @M.MVector)
+
+
+instance HashTableTest M.MVector UM.MVector where
+  specDescription _ _ = "Data.Vector.HashTables.Mutable keys and Data.Vector.HashTables.Unboxed.Mutable values"
+  testInit _ _ n = VH.initialize n
+  testInitCollide _ _ n = VH.initialize n
+  testInsert = VH.insert
+  testAt = VH.at
+  testAt' = VH.at'
+  testDelete = VH.delete
+  testInsertCollide = VH.insert
+  testAtCollide = VH.at
+
+  testLength = VH.length
+  testFromList _ _ = VH.fromList
+  testToList = VH.toList
+
+unboxedKeysSpec :: Spec
+unboxedKeysSpec = mkSpec (Proxy @M.MVector) (Proxy @UM.MVector)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/vector-hashtables.cabal
+++ b/vector-hashtables.cabal
@@ -53,10 +53,24 @@ test-suite vector-hashtables-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  build-depends:       base
-                     , vector-hashtables
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
+  other-modules:       Data.Vector.HashTablesSpec
+  build-depends:       base
+                     , primitive
+                     , containers
+                     , hashable
+                     , vector
+                     , vector-hashtables
+
+  -- Additional dependencies
+  build-depends:
+      hspec                >= 2.6.0    && < 2.8
+    , QuickCheck           >= 2.12.6.1 && < 2.15
+    , quickcheck-instances >= 0.3.19   && < 0.4
+
+  build-tool-depends:
+    hspec-discover:hspec-discover >= 2.6.0 && < 2.8
 
 source-repository head
   type:     git


### PR DESCRIPTION
For mutable hash tables following tests were added:
- lookup for inserted value at specific index returns value;
- lookup for inserted value at specific index returns nothing;
- lookup for inserted value at specific index throws error;
- lookup for updated value at specific index returns updated value;
- lookup for deleted value at specific index returns nothing;
- lookup for deleted value at specific index throws error;
- table size increases when multiple elements added;
- lookup for inserted value with hash collision returns value;
- fromList . toList === id.

In `Internal.hs` following functions were added:
- `at'`,
- `fromList`,
- `toList`.